### PR TITLE
Removed XML file extension from defaultExtensions to mitigate XSS

### DIFF
--- a/src/Filesystem/Definitions.php
+++ b/src/Filesystem/Definitions.php
@@ -118,7 +118,6 @@ class Definitions
             'pdf',
             'swf',
             'txt',
-            'xml',
             'ods',
             'xls',
             'xlsx',
@@ -138,7 +137,6 @@ class Definitions
             'webm',
             'mkv',
             'rar',
-            'xml',
             'zip'
         ];
     }


### PR DESCRIPTION
XML file extensions should not be allowed to upload as they can be used for rendering malicious code ie. cross site scripting.

### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL:https://huntr.dev/bounties/1-packagist-october/rain/

### ⚙️ Description *

Cross Site Scripting is a vulnerabilitiy in a web application which allows an attacker to run malicious JavaScript code on the device of a victim. This fix removes the XML file uploads as XML is rendered by the browser which can allow an attacker to perform a Stored Cross Site Scripting.

### 💻 Technical Description *

October CMS uses this library to handle file uploads. But the XML files are allowed to be uploaded which can be used to upload XSS payloads utilizing XML namespaces. 

### 🐛 Proof of Concept (PoC) *

Using any user account with the file upload privileges, visit `/backend/backend/media` in October CMS and upload the following XML file:

```
<script xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg">
alert('xss');
</script>
```

Now you have the XML file uploaded to storage. Visit its URL by using Click Here link on the Media page and you the alert box pops up.

### 🔥 Proof of Fix (PoF) *

Since XML files are not allowed to be uploaded, the XSS via XML files is n longer possible.

### 👍 User Acceptance Testing (UAT)

Generic fix. I think it should not break any functionallity. 
